### PR TITLE
fix invisible armour stands not being invisible

### DIFF
--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/EntityMetadata.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/EntityMetadata.java
@@ -1,7 +1,9 @@
 package protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
 import protocolsupport.api.MaterialAPI;
 import protocolsupport.api.ProtocolVersion;
 import protocolsupport.protocol.ConnectionImpl;
@@ -54,7 +56,7 @@ public class EntityMetadata extends MiddleEntityMetadata {
 		boolean hasName = entity.getDataCache().getPeBaseFlag(PeMetaBase.FLAG_ALWAYS_SHOW_NAMETAG);
 		boolean isInvisible = entity.getDataCache().getPeBaseFlag(PeMetaBase.FLAG_INVISIBLE);
 		if (isInvisible && hasName) {
-			entity.getDataCache().setPeBaseFlag(PeMetaBase.FLAG_INVISIBLE, false);
+			entity.getDataCache().setPeBaseFlag(PeMetaBase.FLAG_INVISIBLE, ((CraftEntity)Bukkit.getEntity(entity.getUUID())).getHandle().isInvisible());
 			entityRemapper.getRemappedMetadata().put(PeMetaBase.SCALE, new DataWatcherObjectFloatLe(0));
 			entityRemapper.getRemappedMetadata().put(PeMetaBase.BOUNDINGBOX_HEIGTH, new DataWatcherObjectFloatLe(0));
 			entityRemapper.getRemappedMetadata().put(PeMetaBase.BOUNDINGBOX_WIDTH, new DataWatcherObjectFloatLe(0));


### PR DESCRIPTION
WARNING! USES NMS! (couldn't find another way to do this)
it said that bedrock invisible entities cannot have custom names. We could try to replace this by checking if the entity is invisible and has a custom name, and if yes, use an area effect cloud (if you don't set a potion type, it's invisible), or horse variant -1, then set it to a custom name, so the hologram (that's probably what an invisible armor stand with a custom name is!) still works, and doesn't look weird.